### PR TITLE
Missing bracket in css caused media queries to break

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -131,7 +131,8 @@ body {
 
 .previewImg {
 	max-height: 100px;
-	max-width: 100px;
+	max-width: 100px; 
+}
 
 /* MEDIA QUERIES */
 @media (max-width: 500px) {


### PR DESCRIPTION
In the css file, .previewImage was missing the bracket at the end of it. This caused the media queries that came after it to no longer function. Added the bracket and all is now good.