### PR TITLE
Fixed guest doc create button

### DIFF
--- a/public/js/medid/creator.js
+++ b/public/js/medid/creator.js
@@ -127,7 +127,7 @@ define(['jquery', 'medid/card', 'medid/document'], function($, MIDcard, MIDdocum
             fields.push({label: label.val(), field: field.val(), inprofile: inprofile});
         });
 
-        creator.userName = creator.name.val();
+        creator.userName = creator.name.val() || "";
     
         if (creator.picture.attr('src') != 'img/placeholder.png') {
             creator.image = creator.picture.attr('src');


### PR DESCRIPTION
Fixed the create document button for guests. The creator.userName wasn't filled for guest users, so I made it go blank if creator.name is not filled.